### PR TITLE
method_exists in favor of is_callable

### DIFF
--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -103,10 +103,10 @@ function exceptionHandler($exception)
 	$trace = $exception->getTrace();
 
 	// specific name
-	$name = (is_callable(array($exception, 'getName'))) ? $exception->getName() : get_class($exception);
+	$name = (method_exists($exception, 'getName')) ? $exception->getName() : get_class($exception);
 
 	// spoon type exception
-	if(is_callable(array($exception, 'getName')) && strtolower(substr($exception->getName(), 0, 5)) == 'spoon' && $exception->getCode() != 0)
+	if(method_exists($exception, 'getName') && strtolower(substr($exception->getName(), 0, 5)) == 'spoon' && $exception->getCode() != 0)
 	{
 		$documentation = '&raquo; <a href="http://www.spoon-library.com/exceptions/detail/' . $exception->getCode() . '">view documentation</a>';
 	}
@@ -331,7 +331,7 @@ function exceptionHandler($exception)
 	';
 
 	// obfuscate
-	if(is_callable(array($exception, 'getObfuscate')) && count($exception->getObfuscate()) != 0)
+	if(method_exists($exception, 'getObfuscate') && count($exception->getObfuscate()) != 0)
 	{
 		$output = str_replace($exception->getObfuscate(), '***', $output);
 	}


### PR DESCRIPTION
The exception handler checks if a getName() method is callable on the
handled exception, this goes horribly wrong when dealing with external
libraries where an exception class supports the __call() method,
Twig_Error for instance; is_callable() on an instance of such class will
always return 'true' even though the method is not really defined in the
class...

In the specific case of Twig_Error this results in a
BadMethodCallException being thrown when Spoon's exception handler
wrongly tries to send it the 'getName' message.

Since is_callable() in the exception handler is actually used to check
if a method exists, resorting to the more semantically correct
'method_exists' seems in order.
