### PR TITLE
Radiobutton strict comparison for checked value

### DIFF
--- a/spoon/form/radiobutton.php
+++ b/spoon/form/radiobutton.php
@@ -282,7 +282,7 @@ class SpoonFormRadiobutton extends SpoonFormElement
 			$element[$name] = '<input type="radio" name="' . $this->name . '" value="' . $value . '"';
 
 			// checked status
-			if($value == $this->getChecked()) $element[$name] .= ' checked="checked"';
+			if($value === $this->getChecked()) $element[$name] .= ' checked="checked"';
 
 			// add attributes
 			$element[$name] .= $this->getAttributesHTML($value, array('[id]' => $this->variables[$value]['id'], '[value]' => $value));


### PR DESCRIPTION
Spoon will check the radiobutton with value 0 eventhough you gave null as checked param. A strict comparison will fix this issue.
