### PR TITLE
Spoon database: simple but very effective row count fix.

### DIFF
--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -476,7 +476,7 @@ class SpoonDatabase
 		if($this->debug) $this->queries[] = array('query' => $query, 'parameters' => $parameters);
 
 		// number of results
-		return count($statement->fetchAll(PDO::FETCH_COLUMN));
+		return $statement->rowCount();
 	}
 
 

--- a/spoon/tests/database/SpoonDatabaseLargeDataSet.php
+++ b/spoon/tests/database/SpoonDatabaseLargeDataSet.php
@@ -12,7 +12,6 @@
  *
  * And run counting test:
  * phpunit --filter testGetNumRows spoon/tests/database/SpoonDatabaseLargeDataSet.php
- * phpunit --filter testGetRowCount spoon/tests/database/SpoonDatabaseLargeDataSet.php
  *
  */
 

--- a/spoon/tests/database/SpoonDatabaseLargeDataSet.php
+++ b/spoon/tests/database/SpoonDatabaseLargeDataSet.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * This test is not named xxxxxxxxTest.php so it will not be run when you run all tests
+ *
+ * Run manual: phpunit spoon/tests/database/SpoonDatabaseLargeDataSet.php
+ *
+ * Or
+ *
+ * Run once (to create data rows):
+ * phpunit spoon/tests/database/SpoonDatabaseLargeDataSet.php
+ *
+ * And run counting test:
+ * phpunit --filter testGetNumRows spoon/tests/database/SpoonDatabaseLargeDataSet.php
+ * phpunit --filter testGetRowCount spoon/tests/database/SpoonDatabaseLargeDataSet.php
+ *
+ */
+
+$includePath = dirname(dirname(dirname(dirname(__FILE__))));
+set_include_path(get_include_path() . PATH_SEPARATOR . $includePath);
+
+require_once 'spoon/spoon.php';
+
+class SpoonDatabaseLargeDataSet extends PHPUnit_Framework_TestCase
+{
+	const NUMBER_OF_ROWS = 1000000;
+	/**
+	 * @var	SpoonDatabase
+	 */
+	protected $db;
+
+	/**
+	 *
+	 */
+	public function setup()
+	{
+		$this->db = new SpoonDatabase('mysql', 'localhost', 'spoon', 'spoon', 'spoon_tests');
+	}
+
+	/**
+	 * @throws SpoonDatabaseException
+	 */
+	public function testExecute()
+	{
+		// clear all tables
+		if(count($this->db->getTables()) != 0) $this->db->drop($this->db->getTables());
+
+		// create table users
+		$this->db->execute("
+			CREATE TABLE users (
+			id INT( 11 ) NOT NULL AUTO_INCREMENT PRIMARY KEY ,
+			username VARCHAR( 255 ) NOT NULL ,
+			email VARCHAR( 255 ) NOT NULL ,
+			developer ENUM( 'Y', 'N' ) NOT NULL
+			) ENGINE = MYISAM;");
+
+	}
+
+	/**
+	 * @throws SpoonDatabaseException
+	 */
+	public function testInsert()
+	{
+		$userRecord['username'] = 'username';
+		$userRecord['email'] = 'username@domain.extension';
+		$userRecord['developer'] = 'N';
+
+		for($i = 0; $i < self::NUMBER_OF_ROWS; $i++) {
+			$this->db->insert('users', $userRecord);
+		}
+	}
+
+	/**
+	 * @throws SpoonDatabaseException
+	 */
+	public function testGetNumRows()
+	{
+		$this->assertEquals(self::NUMBER_OF_ROWS, $this->db->getNumRows('SELECT id FROM users'));
+		$this->assertEquals(10000, $this->db->getNumRows('SELECT id FROM users LIMIT ?', array(10000)));
+	}
+
+}


### PR DESCRIPTION
While managing an activity log in forkcms backend, I got out of memory errors when I had around 800000 rows in my datagrid. It was caused by a bad way of determining the number of rows, using PDOStatement::fetchAll().

As quoted on http://php.net/manual/en/pdostatement.fetchall.php#refsect1-pdostatement.fetchall-returnvalues.
`Using this method to fetch large result sets will result in a heavy demand on system and possibly network resources.`

You will start seeing differences when you have 10000 rows or more.

Test below is counting 1000000 (one million) rows.

Old
```
$ phpunit --filter testGetNumRows spoon/tests/database/SpoonDatabaseLargeDataSet.php
PHPUnit 4.4.2 by Sebastian Bergmann.

Configuration read from /data/project/bart-forkcms-library/phpunit.xml.dist

.

Time: 420 ms, Memory: 259.25Mb

OK (1 test, 2 assertions)
```

New
```
$ phpunit --filter testGetNumRows spoon/tests/database/SpoonDatabaseLargeDataSet.php
PHPUnit 4.4.2 by Sebastian Bergmann.

Configuration read from /data/project/bart-forkcms-library/phpunit.xml.dist

.

Time: 157 ms, Memory: 7.50Mb

OK (1 test, 2 assertions)
```

New is saving quite some memory and time.

(^_^)

