### PR TITLE
Removed "value of the cookie xx could not be retrieved" exception.

### DIFF
--- a/spoon/CHANGELOG
+++ b/spoon/CHANGELOG
@@ -4,6 +4,9 @@ Bugfixes:
 
 * Locale: some countries where in wrong continent.
 
+Improvements:
+
+* Removed "value of the cookie xx could not be retrieved" exception.
 
 1.3.4 (2013-02-07)
 ----

--- a/spoon/cookie/cookie.php
+++ b/spoon/cookie/cookie.php
@@ -116,10 +116,8 @@ class SpoonCookie
 		// unserialize
 		$actualValue = @unserialize($value);
 
-		// unserialize failed
-		if($actualValue === false && serialize(false) != $value) throw new SpoonCookieException('The value of the cookie "' . $key . '" could not be retrieved. This might indicate that it has been tampered with OR the cookie was initially not set using SpoonCookie.');
+		// when unserialize fails it will return false. No problem.
 
-		// everything is fine
 		return $actualValue;
 	}
 


### PR DESCRIPTION
Sometimes people "clear" their cookie values. So the cookie is still there but the value is empty.
This makes spoon/cookie stop with a SpoonCookieExpception, not nice.

Removed the exception, so false will be return.

More info can be found here:
https://github.com/forkcms/forkcms/issues/845
