### PR TITLE
getTimeAgo: Use required_once instead of require

### DIFF
--- a/spoon/date/date.php
+++ b/spoon/date/date.php
@@ -87,7 +87,7 @@ class SpoonDate
 		$locale = array();
 
 		// fetch language
-		require 'spoon/locale/data/' . $language . '.php';
+		require_once 'spoon/locale/data/' . $language . '.php';
 
 		// get seconds between given timestamp and current timestamp
 		$secondsBetween = time() - $timestamp;


### PR DESCRIPTION
When using the getTimeAgo-method a lot of times f.e. in a datagrid, the locale-file is reloaded every time. This causes (big) performance issues in bigger datagrids. When using require_once, the loading only happens only once.