### PR TITLE
Remove typehints on SpoonTemplate.

### DIFF
--- a/spoon/form/button.php
+++ b/spoon/form/button.php
@@ -103,7 +103,7 @@ class SpoonFormButton extends SpoonFormAttributes
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// start element
 		$output = '<input type="' . $this->type . '" value="' . SpoonFilter::htmlspecialchars($this->value) . '"';

--- a/spoon/form/checkbox.php
+++ b/spoon/form/checkbox.php
@@ -256,7 +256,7 @@ class SpoonFormCheckbox extends SpoonFormAttributes
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for checkbox. Please provide a name.');

--- a/spoon/form/date.php
+++ b/spoon/form/date.php
@@ -371,7 +371,7 @@ class SpoonFormDate extends SpoonFormInput
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a date field. Please provide a valid name.');

--- a/spoon/form/dropdown.php
+++ b/spoon/form/dropdown.php
@@ -451,7 +451,7 @@ class SpoonFormDropdown extends SpoonFormAttributes
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a dropdown menu. Please provide a name.');

--- a/spoon/form/element.php
+++ b/spoon/form/element.php
@@ -125,7 +125,7 @@ class SpoonFormElement
 	 *
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// filled by subclasses
 	}

--- a/spoon/form/file.php
+++ b/spoon/form/file.php
@@ -385,7 +385,7 @@ class SpoonFormFile extends SpoonFormAttributes
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a file field. Please provide a name.');

--- a/spoon/form/form.php
+++ b/spoon/form/form.php
@@ -961,7 +961,7 @@ class SpoonForm
 	 *
 	 * @param	SpoonTemplate $template		The template to parse the form in.
 	 */
-	public function parse(SpoonTemplate $template)
+	public function parse($template)
 	{
 		// loop objects
 		foreach($this->objects as $name => $object)

--- a/spoon/form/hidden.php
+++ b/spoon/form/hidden.php
@@ -106,7 +106,7 @@ class SpoonFormHidden extends SpoonFormAttributes
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// start html generation
 		$output = '<input type="hidden" value="' . $this->getValue() . '"';

--- a/spoon/form/multi_checkbox.php
+++ b/spoon/form/multi_checkbox.php
@@ -248,7 +248,7 @@ class SpoonFormMultiCheckbox extends SpoonFormElement
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name required
 		if($this->name == '') throw new SpoonFormException('A name is required for checkbox. Please provide a name.');

--- a/spoon/form/password.php
+++ b/spoon/form/password.php
@@ -267,7 +267,7 @@ class SpoonFormPassword extends SpoonFormInput
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a password field. Please provide a name.');

--- a/spoon/form/radiobutton.php
+++ b/spoon/form/radiobutton.php
@@ -268,7 +268,7 @@ class SpoonFormRadiobutton extends SpoonFormElement
 	 * @return	array
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name required
 		if($this->name == '') throw new SpoonFormException('A name is required for a radiobutton. Please provide a name.');

--- a/spoon/form/text.php
+++ b/spoon/form/text.php
@@ -770,7 +770,7 @@ class SpoonFormText extends SpoonFormInput
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a textfield. Please provide a name.');

--- a/spoon/form/textarea.php
+++ b/spoon/form/textarea.php
@@ -293,7 +293,7 @@ class SpoonFormTextarea extends SpoonFormInput
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is requird for a textarea. Please provide a valid name.');

--- a/spoon/form/time.php
+++ b/spoon/form/time.php
@@ -210,7 +210,7 @@ class SpoonFormTime extends SpoonFormInput
 	 * @return	string
 	 * @param	SpoonTemplate[optional] $template	The template to parse the element in.
 	 */
-	public function parse(SpoonTemplate $template = null)
+	public function parse($template = null)
 	{
 		// name is required
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a time field. Please provide a name.');


### PR DESCRIPTION
We want to convert to TwigTemplates in Fork, and we need to extend Spoon
to do it. We can't decently inject our TwigTemplates in these methods
when the typehint is in there though.