### PR TITLE
Added optional $unixSocket to SpoonDatabase

### DIFF
--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -111,12 +111,13 @@ class SpoonDatabase
 	/**
 	 * Creates a database connection instance.
 	 *
-	 * @param	string $driver			The driver to use. Available drivers depend on your server configuration.
-	 * @param	string $hostname		The host or IP of your database server.
-	 * @param	string $username		The username to authenticate on your database server.
-	 * @param	string $password		The password to authenticate on your database server.
-	 * @param	string $database		The name of the database to use.
-	 * @param	int[optional] $port		The port to connect on.
+	 * @param	string $driver					The driver to use. Available drivers depend on your server configuration.
+	 * @param	string $hostname				The host or IP of your database server.
+	 * @param	string $username				The username to authenticate on your database server.
+	 * @param	string $password				The password to authenticate on your database server.
+	 * @param	string $database				The name of the database to use.
+	 * @param	int[optional] $port				The port to connect on.
+	 * @param   string[optional] $unixSocket 	The unixSocket which can be used in f.e. a connection with MAMP on MAC.
 	 */
 	public function __construct($driver, $hostname, $username, $password, $database, $port = null, $unixSocket = null)
 	{
@@ -716,7 +717,7 @@ class SpoonDatabase
 	/**
 	 * Retrieve the unix socket.
 	 *
-	 * @return	string	The username.
+	 * @return	string	The path to the unix socket (f.e.: used on MAC with MAMP).
 	 */
 	public function getUnixSocket()
 	{

--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -94,6 +94,13 @@ class SpoonDatabase
 
 
 	/**
+	 * Unix socket
+	 *
+	 * @var	string
+	 */
+	private $unixSocket;
+
+	/**
 	 * Database username
 	 *
 	 * @var	string
@@ -111,7 +118,7 @@ class SpoonDatabase
 	 * @param	string $database		The name of the database to use.
 	 * @param	int[optional] $port		The port to connect on.
 	 */
-	public function __construct($driver, $hostname, $username, $password, $database, $port = null)
+	public function __construct($driver, $hostname, $username, $password, $database, $port = null, $unixSocket = null)
 	{
 		$this->setDriver($driver);
 		$this->setHostname($hostname);
@@ -119,6 +126,7 @@ class SpoonDatabase
 		$this->setPassword($password);
 		$this->setDatabase($database);
 		$this->setPort($port);
+		$this->setUnixSocket($unixSocket);
 	}
 
 
@@ -141,6 +149,11 @@ class SpoonDatabase
 				if($this->port !== null)
 				{
 					$dsn .= ';port=' . $this->port;
+				}
+
+				if($this->unixSocket !== null)
+				{
+					$dsn .= ';unix_socket=' . $this->unixSocket;
 				}
 
 				// create handler
@@ -701,6 +714,16 @@ class SpoonDatabase
 
 
 	/**
+	 * Retrieve the unix socket.
+	 *
+	 * @return	string	The username.
+	 */
+	public function getUnixSocket()
+	{
+		return $this->unixSocket;
+	}
+
+	/**
 	 * Retrieve the username.
 	 *
 	 * @return	string	The username.
@@ -1025,6 +1048,17 @@ class SpoonDatabase
 	private function setPort($port)
 	{
 		$this->port = (int) $port;
+	}
+
+
+	/**
+	 * Set unix socket
+	 *
+	 * @param	string $unixSocket	The path to the unix socket (f.e.: used on MAC with MAMP).
+	 */
+	private function setUnixSocket($unixSocket)
+	{
+		$this->unixSocket = (string) $unixSocket;
 	}
 
 

--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -1056,9 +1056,9 @@ class SpoonDatabase
 	 *
 	 * @param	string $unixSocket	The path to the unix socket (f.e.: used on MAC with MAMP).
 	 */
-	private function setUnixSocket($unixSocket)
+	private function setUnixSocket($unixSocket = null)
 	{
-		$this->unixSocket = (string) $unixSocket;
+		$this->unixSocket = $unixSocket;
 	}
 
 


### PR DESCRIPTION
The $unixSocket must be set when using app/console in Fork CMS. Because
SpoonDatabase could not be found when using MAMP on a Mac.

Add unix_socket in **app/config/config.yml**
```yaml
services:
    database:
        class: SpoonDatabase
        arguments:
            - %database.driver%
            - %database.host%
            - %database.user%
            - %database.password%
            - %database.name%
            - %database.port%
            # only when using MAMP
            - %database.unix_socket%
```
And in **app/config/parameters.yml**
```yaml
parameters:
    # only when using MAMP
    database.unix_socket:   /Applications/MAMP/tmp/mysql/mysql.sock
```