### PR TITLE
Bugfix when having multi-array arrays

### DIFF
--- a/spoon/filter/filter.php
+++ b/spoon/filter/filter.php
@@ -236,17 +236,20 @@ class SpoonFilter
 		// variable is an array
 		if(is_array($variable) && !empty($variable))
 		{
+			// we have values
+			if($values !== null) {
+				// fetch difference between the 2 arrays
+				$differences = array_diff($variable, $values);
+
+				// set value
+				if(count($variable) != count($differences)) $value = array_intersect($variable, $values);
+
+				// values was empty
+				elseif(empty($values)) $value = $variable;
 			// no values
-			if($values === null) $values = array();
-
-			// fetch difference between the 2 arrays
-			$differences = array_diff($variable, $values);
-
-			// set value
-			if(count($variable) != count($differences)) $value = array_intersect($variable, $values);
-
-			// values was empty
-			elseif(empty($values)) $value = $variable;
+			} else {
+				$value = $variable;
+			}
 		}
 
 		// provided values


### PR DESCRIPTION
**How I discovered bug**
I was using AJAX calls with multi-array post parameters.
f.e:

```
update_item[0][1] = 2
update_item[0][2] = 36
update_item[1][1] = 2
update_item[1][2] = 38
```

Then in the AJAX call, a $update = \SpoonFilter::getPostValue('update_item', null, null, 'array');
Which throws an Array to String conversion error.

The code in this PR fixes this "error thrown".
