### PR TITLE
Make sure our db always uses UTF8

### DIFF
--- a/spoon/database/database.php
+++ b/spoon/database/database.php
@@ -158,6 +158,8 @@ class SpoonDatabase
 				{
 					$dsn .= ';unix_socket=' . $this->unixSocket;
 				}
+				
+				$dsn .= ';charset=utf8';
 
 				// create handler
 				$this->handler = new PDO($dsn, $this->username, $this->password);


### PR DESCRIPTION
on some php installs, 'SET NAMES utf8' and 'SET CHARACTER SET utf8' isn't enough.