### PR TITLE
Forms syntax

### DIFF
--- a/spoon/form/input.php
+++ b/spoon/form/input.php
@@ -129,4 +129,16 @@ class SpoonFormInput extends SpoonFormAttributes
 		$this->errors = (string) $error;
 		return $this;
 	}
+
+	/**
+	 * Marks a field as required
+	 *
+	 * @return self
+	 */
+	public function makeRequired()
+	{
+		$this->setAttribute('required', 'required');
+
+		return $this;
+	}
 }

--- a/spoon/form/text.php
+++ b/spoon/form/text.php
@@ -797,4 +797,18 @@ class SpoonFormText extends SpoonFormInput
 
 		return $output;
 	}
+
+	/**
+	 * Sets the html type attribute. This makes it easier to mark a field as
+	 * email/number/...
+	 *
+	 * @param string
+	 * @return self
+	 */
+	public function setType($type)
+	{
+		$this->setAttribute('type', $type);
+
+		return $this;
+	}
 }

--- a/spoon/tests/form/SpoonFormTextTest.php
+++ b/spoon/tests/form/SpoonFormTextTest.php
@@ -292,4 +292,13 @@ class SpoonFormTextTest extends PHPUnit_Framework_TestCase
 		$_POST['name'] = array('foo', 'bar');
 		$this->assertEquals('Array', $this->txtName->getValue());
 	}
+
+	public function testType()
+	{
+		$this->txtName->setType('email');
+		$this->assertEquals(
+			'email',
+			$this->txtName->getAttributes()['type']
+		);
+	}
 }

--- a/spoon/tests/form/SpoonFormTextTest.php
+++ b/spoon/tests/form/SpoonFormTextTest.php
@@ -301,4 +301,34 @@ class SpoonFormTextTest extends PHPUnit_Framework_TestCase
 			$this->txtName->getAttributes()['type']
 		);
 	}
+
+	public function testRequired()
+	{
+		$this->txtName->makeRequired();
+		$this->assertEquals(
+			'required',
+			$this->txtName->getAttributes()['required']
+		);
+	}
+
+	public function testChainingMethods()
+	{
+		$this->txtName
+			->setType('email')
+			->makeRequired()
+			->setError('test');
+
+		$this->assertEquals(
+			'email',
+			$this->txtName->getAttributes()['type']
+		);
+		$this->assertEquals(
+			'required',
+			$this->txtName->getAttributes()['required']
+		);
+		$this->assertEquals(
+			'test',
+			$this->txtName->getErrors()
+		);
+	}
 }


### PR DESCRIPTION
Some shorthand methods. This PR changes

```php
$form
    ->addText('email')
    ->setAttributes(array(
        'required' => 'required',
        'type' => 'email',
    ))
;
```

to

```php
$form
    ->addText('email')
    ->setType('email')
    ->makeRequired()
;
```