### PR TITLE
Bug modifier vars

### DIFF
--- a/spoon/tests/template/SpoonCompilerTest.php
+++ b/spoon/tests/template/SpoonCompilerTest.php
@@ -393,6 +393,13 @@ class SpoonTemplateCompilerTest extends PHPUnit_Framework_TestCase
 		$this->runTests('Object name', 'template_modifier_object.tpl');
 	}
 
+	function testTemplateModifierWithVariables()
+	{
+		$this->tpl->assign('string', '%1$s %2$s');
+		$this->tpl->assign('array', array('foo' => 'foo', 'bar' => 'bar'));
+		$this->runTests('foo bar', 'template_modifier_with_vars.tpl');
+	}
+
 	/**
 	 * Check if the given templates gives the wanted output in debug and non
 	 * debug mode

--- a/spoon/tests/template/SpoonCompilerTest.php
+++ b/spoon/tests/template/SpoonCompilerTest.php
@@ -400,6 +400,18 @@ class SpoonTemplateCompilerTest extends PHPUnit_Framework_TestCase
 		$this->runTests('foo bar', 'template_modifier_with_vars.tpl');
 	}
 
+	function testTemplateModifierInIterationOverArrayOfObjects()
+	{
+		$object1 = new Object();
+		$object1->setName('foo');
+
+		$object2 = new Object();
+		$object2->setName('bar');
+
+		$this->tpl->assign('array', array($object1, $object2));
+		$this->runTests('FooBar', 'template_modifier_iteration_over_array_of_objects.tpl');
+	}
+
 	/**
 	 * Check if the given templates gives the wanted output in debug and non
 	 * debug mode

--- a/spoon/tests/template/templates/template_modifier_iteration_over_array_of_objects.tpl
+++ b/spoon/tests/template/templates/template_modifier_iteration_over_array_of_objects.tpl
@@ -1,0 +1,1 @@
+{iteration:array}{$array.name|ucfirst}{/iteration:array}

--- a/spoon/tests/template/templates/template_modifier_with_vars.tpl
+++ b/spoon/tests/template/templates/template_modifier_with_vars.tpl
@@ -1,0 +1,1 @@
+{$string|sprintf:{$array.foo}:{$array.bar}}


### PR DESCRIPTION
Throw an exception when trying to use template modifiers on objects with variables

These would cause a parse error because the variables inside the the modifier call
would be rendered by surround it with the <?php ?> tag.