### PR TITLE
Fix xss in SpoonForms.

### DIFF
--- a/spoon/form/form.php
+++ b/spoon/form/form.php
@@ -982,6 +982,8 @@ class SpoonForm
 	 */
 	public function setAction($action)
 	{
+		$action = str_replace('"', '&qout;', $action);
+
 		$this->action = (string) $action;
 	}
 


### PR DESCRIPTION
When an action name contained quote characters, the form html breaks and
stuff could be injected in there. This is f.e. the case in the backend
of Fork CMS.

Related issue: https://github.com/forkcms/forkcms/issues/1405