### PR TITLE
Fixes `null` values from being converted to empty string in SpoonDataGrid columnFunctions

### DIFF
--- a/spoon/datagrid/datagrid.php
+++ b/spoon/datagrid/datagrid.php
@@ -1019,8 +1019,8 @@ class SpoonDataGrid
 			// array
 			elseif(is_array($function['arguments']))
 			{
-                // replace arguments
-                $function['arguments'] = json_decode(str_replace($record['labels'], $record['values'], json_encode($function['arguments'])));
+				// replace arguments
+				$function['arguments'] = json_decode(str_replace($record['labels'], $record['values'], json_encode($function['arguments'])));
 
 				// execute function
 				$value = call_user_func_array($function['function'], $function['arguments']);

--- a/spoon/datagrid/datagrid.php
+++ b/spoon/datagrid/datagrid.php
@@ -1019,8 +1019,8 @@ class SpoonDataGrid
 			// array
 			elseif(is_array($function['arguments']))
 			{
-				// replace arguments
-				$function['arguments'] = str_replace($record['labels'], $record['values'], $function['arguments']);
+                // replace arguments
+                $function['arguments'] = json_decode(str_replace($record['labels'], $record['values'], json_encode($function['arguments'])));
 
 				// execute function
 				$value = call_user_func_array($function['function'], $function['arguments']);


### PR DESCRIPTION
## Problem

Full [problem description](https://github.com/forkcms/forkcms/issues/2052).

Summary:
When giving a null to a SpoonDataGrid columnFunction, this will be converted to a string. But that isn't wanted behavior since we are using PHP 7.1 type casting.

## Solution

The json_decode/encode is 3x faster then str_replace and ALSO fixes the problem. 
http://php.net/manual/en/function.str-replace.php