### PR TITLE
Fix json as parameter for datagrid functions

### DIFF
--- a/spoon/datagrid/datagrid.php
+++ b/spoon/datagrid/datagrid.php
@@ -1020,7 +1020,19 @@ class SpoonDataGrid
 			elseif(is_array($function['arguments']))
 			{
 				// replace arguments
-				$function['arguments'] = json_decode(str_replace($record['labels'], $record['values'], json_encode($function['arguments'])));
+				$values = array_combine($record['labels'], $record['values']);
+				$function['arguments'] = array_map(
+					function ($argument) use ($values) {
+						return preg_replace_callback('(\[[^\n ]*?\])', function ($matches) use ($values) {
+							if (!array_key_exists($matches[0], $values)) {
+								return $matches[0];
+							}
+
+							return $values[$matches[0]];
+						}, $argument);
+					},
+					$function['arguments']
+				);
 
 				// execute function
 				$value = call_user_func_array($function['function'], $function['arguments']);


### PR DESCRIPTION
There was a fix added to prevent null form turning into an empty string but that gave issues when the argument was a json or serialised string