### PR TITLE
Use a valid license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "library",
 	"description": "A PHP5 library that is fast, easy to learn and fun!",
 	"homepage": "http://www.spoon-library.com",
-	"license": "BSD",
+	"license": "BSD-1-Clause",
 	"authors": [
 		{
 			"name": "Davy Hellemans",


### PR DESCRIPTION
License “BSD” is not a valid SPDX license identifier, see https://spdx.org/licenses/

BSD 1 Clause seemed like the closest valid match, see https://spdx.org/licenses/BSD-1-Clause.html