### PR TITLE
Use valid composer license

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "library",
 	"description": "A PHP5 library that is fast, easy to learn and fun!",
 	"homepage": "http://www.spoon-library.com",
-	"license": "BSD-1-Clause",
+	"license": "BSD-2-Clause",
 	"authors": [
 		{
 			"name": "Davy Hellemans",


### PR DESCRIPTION
Mail "spoon/library failed to update, invalid composer.json data"

`composer validate` gave following error:
> See https://getcomposer.org/doc/04-schema.md for details on the schema
License "BSD-1-Clause" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.

See https://getcomposer.org/doc/04-schema.md#license