### PR TITLE
Handle SVG file as a normal image

### DIFF
--- a/spoon/form/file.php
+++ b/spoon/form/file.php
@@ -247,13 +247,13 @@ class SpoonFormFile extends SpoonFormAttributes
 		if($this->isFilled())
 		{
 			// get image properties
-			$properties = @getimagesize($_FILES[$this->attributes['name']]['tmp_name']);
+			$mimeType = mime_content_type($_FILES[$this->attributes['name']]['tmp_name']);
 
 			// invalid properties
-			if($properties === false) $return = false;
+			if($mimeType === false) $return = false;
 
 			// search for mime-type
-			else $return = in_array($properties['mime'], $allowedTypes);
+			else $return = in_array($mimeType, $allowedTypes);
 
 			// add error if needed
 			if(!$return && $error !== null) $this->setError($error);


### PR DESCRIPTION
At this moment if you try to upload a SVG file this will most probably not work. Mostly because the PHP function `getimagesize` does not handle SVG. This PR intends to fix this problem.