### PR TITLE
Fix unit tests

### DIFF
--- a/spoon/tests/file/SpoonFileTest.php
+++ b/spoon/tests/file/SpoonFileTest.php
@@ -12,7 +12,7 @@ class SpoonFileTest extends PHPUnit_Framework_TestCase
 		if(!defined('TMPPATH')) define('TMPPATH', dirname(realpath(dirname(__FILE__))) . '/tmp');
 
 		$this->existingUrl = 'http://www.spoon-library.be/downloads/1.0.3/spoon-1.0.3.zip';
-		$this->nonExistingUrl = 'http://ksdgg.com/' . time() . '.txt';
+		$this->nonExistingUrl = 'http://wowbesturleverforspoonlibrary.dev/' . time() . '.txt';
 		$this->destinationFile = TMPPATH . '/spoon.zip';
 	}
 


### PR DESCRIPTION
Unit tests currently fail because they depend on an URL that should not exist. 
This PR changes this URL to a really non-existing one.