### PR TITLE
Prevent object injection through unserialize

### DIFF
--- a/spoon/cookie/cookie.php
+++ b/spoon/cookie/cookie.php
@@ -126,7 +126,7 @@ class SpoonCookie
 				$unserializedValue = unserialize($value);
 
 				// unserialize was successful
-				if ($unserializedValue !== false) {
+				if ($unserializedValue !== false || serialize(false) === $value) {
 					// set the cookie again, but this time json encode it
 					self::set($key, $unserializedValue);
 

--- a/spoon/cookie/cookie.php
+++ b/spoon/cookie/cookie.php
@@ -136,7 +136,7 @@ class SpoonCookie
 		}
 
 		// unserialize failed
-		if($actualValue === null && json_encode(false) != $value) throw new SpoonCookieException('The value of the cookie "' . $key . '" could not be retrieved. This might indicate that it has been tampered with OR the cookie was initially not set using SpoonCookie.');
+		if($actualValue === null && json_encode(null) !== $value) throw new SpoonCookieException('The value of the cookie "' . $key . '" could not be retrieved. This might indicate that it has been tampered with OR the cookie was initially not set using SpoonCookie.');
 
 		// everything is fine
 		return $actualValue;

--- a/spoon/cookie/cookie.php
+++ b/spoon/cookie/cookie.php
@@ -114,10 +114,29 @@ class SpoonCookie
 		$value = (get_magic_quotes_gpc()) ? stripslashes($_COOKIE[$key]) : $_COOKIE[$key];
 
 		// unserialize
-		$actualValue = @unserialize($value);
+		$actualValue = json_decode($value);
+
+		// if the decode failed
+		if ($actualValue === null) {
+			// maybe it's serialized, check if there are any serialized objects in the string.
+			preg_match('/O:\d+:"/', $value, $matches);
+
+			// no objects were found
+			if (empty($matches)) {
+				$unserializedValue = unserialize($value);
+
+				// unserialize was successful
+				if ($unserializedValue !== false) {
+					// set the cookie again, but this time json encode it
+					self::set($key, $unserializedValue);
+
+					return $unserializedValue;
+				}
+			}
+		}
 
 		// unserialize failed
-		if($actualValue === false && serialize(false) != $value) throw new SpoonCookieException('The value of the cookie "' . $key . '" could not be retrieved. This might indicate that it has been tampered with OR the cookie was initially not set using SpoonCookie.');
+		if($actualValue === null && json_encode(false) != $value) throw new SpoonCookieException('The value of the cookie "' . $key . '" could not be retrieved. This might indicate that it has been tampered with OR the cookie was initially not set using SpoonCookie.');
 
 		// everything is fine
 		return $actualValue;
@@ -140,7 +159,7 @@ class SpoonCookie
 	{
 		// redefine
 		$key = (string) $key;
-		$value = serialize($value);
+		$value = json_encode($value);
 		$time = time() + (int) $time;
 		$path = (string) $path;
 		$domain = ($domain !== null) ? (string) $domain : null;


### PR DESCRIPTION
If a user sets a cookie containing an object it might execute some code inside the object when unserializing the object through the `__wakeup` magic method.

This pull request attempts to prevent this by setting and getting cookies through json encode/decode. We've also provided some fallback by checking if the cookie's string contains a serialized object. If it doesn't, we still unserialize the cookie and re-set it using `json_encode`. If the cookie does contain a serialized object an exception will be thrown.

This security fix _will_ break your website if objects are set in cookies.

See https://www.owasp.org/index.php/PHP_Object_Injection for example