### PR TITLE
Define missing userAgent variable

### DIFF
--- a/spoon/exception/exception.php
+++ b/spoon/exception/exception.php
@@ -181,6 +181,7 @@ function getOutput($exception)
 {
     // specific name
     $name = (method_exists($exception, 'getName')) ? $exception->getName() : get_class($exception);
+    $userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '<i>(Unknown)</i>';
 
     // generate output
     $output = '


### PR DESCRIPTION
`$userAgent` variable is being used before it has been defined. This was probably caused by a refactoring a while ago.