### PR TITLE
Mark a form as incorrect when no CSRF token is present in the GET/POST

### DIFF
--- a/spoon/form/form.php
+++ b/spoon/form/form.php
@@ -1081,52 +1081,52 @@ class SpoonForm
 		$this->useToken = (bool) $on;
 	}
 
-    /**
-     * @return bool
-     */
-    protected function sessionHasFormToken()
-    {
-        if (!session_id()) {
-            @session_start();
-        }
+	/**
+	 * @return bool
+	 */
+	protected function sessionHasFormToken()
+	{
+		if (!session_id()) {
+			@session_start();
+		}
 
-        return isset($_SESSION['form_token']);
+		return isset($_SESSION['form_token']);
 	}
 
-    /**
-     * @param string $token
-     */
-    protected function saveTokenToSession($token)
-    {
-        if (!session_id()) {
-            @session_start();
-        }
+	/**
+	 * @param string $token
+	 */
+	protected function saveTokenToSession($token)
+	{
+		if (!session_id()) {
+			@session_start();
+		}
 
-        $_SESSION['form_token'] = $token;
+		$_SESSION['form_token'] = $token;
 	}
 
-    /**
-     * @return string
-     */
-    protected function getSessionId()
-    {
-        if (!session_id()) {
-            @session_start();
-        }
+	/**
+	 * @return string
+	 */
+	protected function getSessionId()
+	{
+		if (!session_id()) {
+			@session_start();
+		}
 
-        return session_id();
+		return session_id();
 	}
 
-    /**
-     * @return string
-     */
-    protected function getTokenFromSession()
-    {
-        if (!session_id()) {
-            @session_start();
-        }
+	/**
+	 * @return string
+	 */
+	protected function getTokenFromSession()
+	{
+		if (!session_id()) {
+			@session_start();
+		}
 
-        return array_key_exists('form_token', $_SESSION) ? $_SESSION['form_token'] : null;
+		return array_key_exists('form_token', $_SESSION) ? $_SESSION['form_token'] : null;
 	}
 
 	/**
@@ -1142,11 +1142,11 @@ class SpoonForm
 		// if we use tokens, we validate them here
 		if($this->getUseToken())
 		{
-            if ($this->getMethod() === 'get' && !isset($_GET['form_token'])
-                || $this->getMethod() === 'post' && !isset($_POST['form_token'])) {
-                $errors[] = $this->tokenError;
-            }
-            
+			if ($this->getMethod() === 'get' && !isset($_GET['form_token'])
+				|| $this->getMethod() === 'post' && !isset($_POST['form_token'])) {
+				$errors[] = $this->tokenError;
+			}
+
 			// token not available?
 			if(!$this->sessionHasFormToken()) {
 				$errors[] = $this->tokenError;

--- a/spoon/form/form.php
+++ b/spoon/form/form.php
@@ -1142,6 +1142,11 @@ class SpoonForm
 		// if we use tokens, we validate them here
 		if($this->getUseToken())
 		{
+            if ($this->getMethod() === 'get' && !isset($_GET['form_token'])
+                || $this->getMethod() === 'post' && !isset($_POST['form_token'])) {
+                $errors[] = $this->tokenError;
+            }
+            
 			// token not available?
 			if(!$this->sessionHasFormToken()) {
 				$errors[] = $this->tokenError;


### PR DESCRIPTION
This fixes a security issue where Spoon would only check if a token was present in the session, and a form_token field was present in the form.

This would always validate as correct, since the form_token field is added in the constructor of the form with the value stored in the session if it exists. 

This allowed CSRF attacks to go through. 

The missing piece of the CSRF protection is to also validate against the $_GET and $_POST parameters. If no form_token parameter is present in those, then we're dealing with a CSRF attack.