### PR TITLE
Fix double encoding issue on text fields

### DIFF
--- a/spoon/form/text.php
+++ b/spoon/form/text.php
@@ -788,7 +788,8 @@ class SpoonFormText extends SpoonFormInput
 		if($this->attributes['name'] == '') throw new SpoonFormException('A name is required for a textfield. Please provide a name.');
 
 		// start html generation
-		$output = '<input value="' . SpoonFilter::htmlspecialchars($this->getValue()) . '"';
+		// note: no need to encode the value here, it gets encoding in the getter as long as $allowHTML=true
+		$output = '<input value="' . $this->getValue() . '"';
 
 		// add attributes
 		$output .= $this->getAttributesHTML(array('[id]' => $this->attributes['id'], '[name]' => $this->attributes['name'], '[value]' => $this->getValue())) . ' />';

--- a/spoon/tests/form/SpoonFormDateTest.php
+++ b/spoon/tests/form/SpoonFormDateTest.php
@@ -168,4 +168,20 @@ class SpoonFormDateTest extends TestCase
 		);
 		$this->loopOverFormats($formats);
 	}
+
+	public function testParse()
+	{
+		$_POST['date'] = '12/10/2026';
+		$this->assertEquals(
+			'<input type="text" value="12/10/2026" id="date" name="date" maxlength="10" data-mask="dd/mm/yy" class="inputDatefield" />',
+			$this->txtDate->parse()
+		);
+
+		// Make sure we encode XSS payloads
+		$_POST['date'] = '12/10/2026\'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt>';
+		$this->assertEquals(
+			'<input type="text" value="12/10/2026&#039;&quot;()%26%25&lt;yes&gt;&lt;ScRiPt%20&gt;alert(1)&lt;/ScRiPt&gt;" id="date" name="date" maxlength="10" data-mask="dd/mm/yy" class="inputDatefield" />',
+			$this->txtDate->parse()
+		);
+	}
 }

--- a/spoon/tests/form/SpoonFormHiddenTest.php
+++ b/spoon/tests/form/SpoonFormHiddenTest.php
@@ -51,4 +51,21 @@ class SpoonFormHiddenTest extends TestCase
 		$_POST['hidden'] = array('foo', 'bar');
 		$this->assertEquals('Array', $this->hidHidden->getValue());
 	}
+
+	public function testParse()
+	{
+		$_POST['form'] = 'hiddenfield';
+		$_POST['hidden'] = 'But I am le tired';
+		$this->assertEquals(
+			'<input type="hidden" value="But I am le tired" id="hidden" name="hidden" />',
+			$this->hidHidden->parse()
+		);
+
+		// Make sure we encode XSS payloads
+		$_POST['hidden'] = 'But I am le tired\'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt>';
+		$this->assertEquals(
+			'<input type="hidden" value="But I am le tired&amp;#039;&amp;quot;()%26%25&amp;lt;yes&amp;gt;&amp;lt;ScRiPt%20&amp;gt;alert(1)&amp;lt;/ScRiPt&amp;gt;" id="hidden" name="hidden" />',
+			$this->hidHidden->parse()
+		);
+	}
 }

--- a/spoon/tests/form/SpoonFormPasswordTest.php
+++ b/spoon/tests/form/SpoonFormPasswordTest.php
@@ -114,4 +114,21 @@ class SpoonFormPasswordTest extends TestCase
 		$_POST['name'] = array('foo', 'bar');
 		$this->assertEquals('Array', $this->txtPassword->getValue());
 	}
+
+	public function testParse()
+	{
+		$_POST['form'] = 'passwordfield';
+		$_POST['name'] = 'But I am le tired';
+		$this->assertEquals(
+			'<input type="password" value="But I am le tired" id="name" name="name" class="inputPassword" />',
+			$this->txtPassword->parse()
+		);
+
+		// Make sure we encode XSS payloads
+		$_POST['name'] = 'But I am le tired\'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt>';
+		$this->assertEquals(
+			'<input type="password" value="But I am le tired&#039;&quot;()%26%25&lt;yes&gt;&lt;ScRiPt%20&gt;alert(1)&lt;/ScRiPt&gt;" id="name" name="name" class="inputPassword" />',
+			$this->txtPassword->parse()
+		);
+	}
 }

--- a/spoon/tests/form/SpoonFormTextTest.php
+++ b/spoon/tests/form/SpoonFormTextTest.php
@@ -336,4 +336,28 @@ class SpoonFormTextTest extends TestCase
 			$this->txtName->getErrors()
 		);
 	}
+
+	public function testParse()
+	{
+		$_POST['form'] = 'textfield';
+		$_POST['name'] = 'But I am le tired';
+		$this->assertEquals(
+			'<input value="But I am le tired" id="name" name="name" type="text" class="inputText" />',
+			$this->txtName->parse()
+		);
+
+		// Make sure we encode XSS payloads
+		$_POST['name'] = 'But I am le tired\'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt>';
+		$this->assertEquals(
+			'<input value="But I am le tired&#039;&quot;()%26%25&lt;yes&gt;&lt;ScRiPt%20&gt;alert(1)&lt;/ScRiPt&gt;" id="name" name="name" type="text" class="inputText" />',
+			$this->txtName->parse()
+		);
+
+		// Make sure we do not do double encoding on the ampersand
+		$_POST['name'] = 'Something & something else';
+		$this->assertEquals(
+			'<input value="Something &amp; something else" id="name" name="name" type="text" class="inputText" />',
+			$this->txtName->parse()
+		);
+	}
 }

--- a/spoon/tests/form/SpoonFormTimeTest.php
+++ b/spoon/tests/form/SpoonFormTimeTest.php
@@ -92,4 +92,21 @@ class SpoonFormTimeTest extends TestCase
 		$_POST['time'] = array('foo', 'bar');
 		$this->assertEquals('Array', $this->txtTime->getValue());
 	}
+
+	public function testParse()
+	{
+		$_POST['form'] = 'timefield';
+		$_POST['time'] = '15:30';
+		$this->assertEquals(
+			'<input type="text" value="15:30" id="time" name="time" maxlength="5" class="inputTimefield" />',
+			$this->txtTime->parse()
+		);
+
+		// Make sure we encode XSS payloads
+		$_POST['time'] = '15:30\'"()%26%25<yes><ScRiPt%20>alert(1)</ScRiPt>';
+		$this->assertEquals(
+			'<input type="text" value="15:30&#039;&quot;()%26%25&lt;yes&gt;&lt;ScRiPt%20&gt;alert(1)&lt;/ScRiPt&gt;" id="time" name="time" maxlength="5" class="inputTimefield" />',
+			$this->txtTime->parse()
+		);
+	}
 }


### PR DESCRIPTION
In #80, additional html encoding was added to rendered input fields to prevent XSS. For example in the datepicker of the Formbuilder module in Fork CMS. 

However, when you edit a page in Fork CMS the page title gets encoded two times. `&` turns into `&amp;` then into `&amp;amp;`

![image](https://user-images.githubusercontent.com/1352979/118364488-e5cce900-b598-11eb-8c7b-373585a74897.png) 


And when I debug the issue, in the `text.php` file of Spoon: 
![image](https://user-images.githubusercontent.com/1352979/118364500-f41b0500-b598-11eb-82ec-798770d1bd24.png)


* You can see that the getter will encode the value here: https://github.com/forkcms/library/blob/6b523ca2f760e16ae1aa474172cccbf7ba61ee89/spoon/form/text.php#L84-L89
* But the parse function also adds encoding since #80 https://github.com/forkcms/library/blob/6b523ca2f760e16ae1aa474172cccbf7ba61ee89/spoon/form/text.php#L791 and this is not necessary

So while other form fields (password, hidden, date, time, ...) did not do HTML encoding before #80, for text fields its actually not necessary as long as `$allowHTML=true` (the default). 


Seems to work now in the pages module:

<img width="1274" alt="image" src="https://user-images.githubusercontent.com/1352979/118364666-b5397f00-b599-11eb-8ac0-efa28407fc9e.png">



Tried a sample XSS payload used in #80 too: 

https://user-images.githubusercontent.com/1352979/118364829-62ac9280-b59a-11eb-8c7e-5fe1b2ee00d3.mp4

