### PR TITLE
Prevent copy failure

### DIFF
--- a/spoon/thumbnail/thumbnail.php
+++ b/spoon/thumbnail/thumbnail.php
@@ -262,7 +262,7 @@ class SpoonThumbnail
 		// file is the same?
 		if(($currentType == IMAGETYPE_GIF && $extension == 'gif') || ($currentType == IMAGETYPE_JPEG && in_array($extension, array('jpg', 'jpeg'))) || ($currentType == IMAGETYPE_PNG && $extension == 'png'))
 		{
-			if($currentWidth == $this->width && $currentHeight == $this->height)
+			if($currentWidth == $this->width && $currentHeight == $this->height && $this->filename != $filename)
 			{
 				return SpoonDirectory::copy($this->filename, $filename, true, true, $chmod);
 			}


### PR DESCRIPTION
When resizing the same file and the requested size is the same as the maximum size, you will get this error:

Uncaught PHP Exception SpoonDirectoryException: "The directory/file (...) couldn't be copied." at spoon/library/spoon/directory/directory.php line 124

When resizing from file1 to file2, and no resize is needed, a file copy is necessary.
But when resizing from file1 to file1, and no resize is needed, the copy function should be skipped.